### PR TITLE
Set the required capacitor version to ^2.4.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "Stewan Silva",
   "license": "MIT",
   "dependencies": {
-    "@capacitor/core": "latest"
+    "@capacitor/core": "^2.4.7"
   },
   "devDependencies": {
     "all-contributors-cli": "^6.16.0",


### PR DESCRIPTION
The plugin depends on @capacitor/core@latest, which currently is v3, but it does not support capacitor v3 yet. This PR sets the required @capacitor/core version to ^2.4.7.