### PR TITLE
Use SDWebImage to convert image into viable format

### DIFF
--- a/CapacitorCommunityMedia.podspec
+++ b/CapacitorCommunityMedia.podspec
@@ -13,5 +13,6 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target  = '13.0'
   s.dependency 'Capacitor'
+  s.dependency 'SDWebImage'
   s.swift_version = '5.1'
 end

--- a/ios/Plugin/MediaPlugin.swift
+++ b/ios/Plugin/MediaPlugin.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Photos
 import Capacitor
+import SDWebImage
 
 public class JSDate {
     static func toString(_ date: Date) -> String {
@@ -90,9 +91,17 @@ public class MediaPlugin: CAPPlugin {
             PHPhotoLibrary.shared().performChanges({
 
                 let url = URL(string: data)
-                let data = try? Data(contentsOf: url!)
+                var data = try? Data(contentsOf: url!)
                 if (data != nil) {
-                    let image = UIImage(data: data!)
+                    var image = UIImage(data: data!)
+                    data = image?.sd_imageData(as: .PNG)
+                    if (data != nil) {
+                        image = UIImage(data: data!)
+                    } else {
+                        call.reject("Image conversion failed")
+                        return
+                    }
+                    
                     let creationRequest = PHAssetChangeRequest.creationRequestForAsset(from: image!)
 
                     if let collection = targetCollection {

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -5,6 +5,7 @@ def capacitor_pods
   use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
+  pod 'SDWebImage', '~> 5.0'
 end
 
 target 'Plugin' do


### PR DESCRIPTION
My application (and I assume a lot of web applications nowadays) works with WebP images, which can't be saved natively with UIImage. This code uses SDWebImage to convert images to PNG before saving them, thus ensuring they can always be saved regardless of format.