### PR TITLE
chore: Exclude example folder from lint/prettier

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 build
 dist
+example

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 build
 dist
+example

--- a/android/src/main/java/com/getcapacitor/community/media/MediaPlugin.java
+++ b/android/src/main/java/com/getcapacitor/community/media/MediaPlugin.java
@@ -6,14 +6,13 @@ import android.content.Context;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
-import android.os.SystemClock;
-import android.util.Base64;
 import android.os.Build;
 import android.os.Environment;
+import android.os.SystemClock;
 import android.provider.MediaStore;
+import android.util.Base64;
 import android.util.Log;
 import android.webkit.MimeTypeMap;
-
 import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Logger;
@@ -24,7 +23,6 @@ import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 import com.getcapacitor.annotation.Permission;
 import com.getcapacitor.annotation.PermissionCallback;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -36,7 +34,6 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
-
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -253,11 +250,7 @@ public class MediaPlugin extends Plugin {
                 }
 
                 try {
-                    inputFile = File.createTempFile(
-                            "tmp",
-                            "." + extension,
-                            getContext().getCacheDir()
-                    );
+                    inputFile = File.createTempFile("tmp", "." + extension, getContext().getCacheDir());
                     OutputStream os = new FileOutputStream(inputFile);
                     os.write(decodedBytes);
                     os.close();

--- a/android/src/main/java/com/getcapacitor/community/media/MediaPluginRequestCodes.java
+++ b/android/src/main/java/com/getcapacitor/community/media/MediaPluginRequestCodes.java
@@ -1,6 +1,7 @@
 package com.getcapacitor.community.media;
 
 public class MediaPluginRequestCodes {
+
     public static final int MEDIA_READ_EXTERNAL_STORAGE_PERMISSION = 19861;
     public static final int MEDIA_WRITE_EXTERNAL_STORAGE_PHOTO_PERMISSION = 19862;
     public static final int MEDIA_WRITE_EXTERNAL_STORAGE_VIDEO_PERMISSION = 19863;

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,50 +1,50 @@
 export interface MediaPlugin {
   /**
-    * Get filtered thumbnails from camera roll. iOS only.
-    * 
-    * [Code Examples](https://github.com/capacitor-community/media/blob/master/example/src/components/GetMedias.tsx)
-    */
+   * Get filtered thumbnails from camera roll. iOS only.
+   *
+   * [Code Examples](https://github.com/capacitor-community/media/blob/master/example/src/components/GetMedias.tsx)
+   */
   getMedias(options?: MediaFetchOptions): Promise<MediaResponse>;
   /**
-    * Get a filesystem path to a full-quality media asset by its identifier. iOS only.
-    * This is not included for Android because on Android, a media asset's identifier IS its path!
-    * You can simply use the Filesystem plugin to work with it. On iOS, you have to turn the identifier into a path
-    * using this function. After that, you can use the Filesystem plugin, same as Android.
-    * 
-    * [Code Examples](https://github.com/capacitor-community/media/blob/master/example/src/components/GetMedias.tsx)
-    */
+   * Get a filesystem path to a full-quality media asset by its identifier. iOS only.
+   * This is not included for Android because on Android, a media asset's identifier IS its path!
+   * You can simply use the Filesystem plugin to work with it. On iOS, you have to turn the identifier into a path
+   * using this function. After that, you can use the Filesystem plugin, same as Android.
+   *
+   * [Code Examples](https://github.com/capacitor-community/media/blob/master/example/src/components/GetMedias.tsx)
+   */
   getMediaByIdentifier(options?: { identifier: string }): Promise<MediaPath>;
   /**
-    * Get list of albums. 
-    * 
-    * [Code Examples](https://github.com/capacitor-community/media/blob/master/example/src/components/GetAlbums.tsx)
-    */
+   * Get list of albums.
+   *
+   * [Code Examples](https://github.com/capacitor-community/media/blob/master/example/src/components/GetAlbums.tsx)
+   */
   getAlbums(): Promise<MediaAlbumResponse>;
   /**
    * Saves a still photo or GIF to the camera roll.
-   * 
-   * On Android and iOS, this supports web URLs, base64 encoded images 
+   *
+   * On Android and iOS, this supports web URLs, base64 encoded images
    * (e.g. data:image/jpeg;base64,...), and local files.
    * On Android, all image formats supported by the user's photo viewer are supported.
    * On iOS, most common image formats are supported.
-   * 
+   *
    * [Code Examples](https://github.com/capacitor-community/media/blob/master/example/src/components/SaveMedia.tsx)
    */
   savePhoto(options?: MediaSaveOptions): Promise<PhotoResponse>;
   /**
    * Saves a video to the camera roll.
-   * 
-   * On Android and iOS, this supports web URLs, base64 encoded videos 
+   *
+   * On Android and iOS, this supports web URLs, base64 encoded videos
    * (e.g. data:image/mp4;base64,...), and local files.
    * On Android, all video formats supported by the user's photo viewer are supported.
    * On iOS, the supported formats are based on whatever iOS supports at the time.
-   * 
+   *
    * [Code Examples](https://github.com/capacitor-community/media/blob/master/example/src/components/SaveMedia.tsx)
    */
   saveVideo(options?: MediaSaveOptions): Promise<PhotoResponse>;
   /**
    * Creates an album.
-   * 
+   *
    * [Code Examples](https://github.com/capacitor-community/media/blob/master/example/src/components/CreateDemoAlbum.tsx)
    */
   createAlbum(options: MediaAlbumCreate): Promise<void>;
@@ -55,9 +55,9 @@ export interface MediaPlugin {
    * are multiple albums with the same name, which is possible on Android.
    * Just compare the albums path to the start of the album identifier when
    * getting albums.
-   * 
+   *
    * Only available on Android.
-   * 
+   *
    * Code Examples: [basic](https://github.com/capacitor-community/media/blob/master/example/src/components/CreateDemoAlbum.tsx), [when saving media](https://github.com/capacitor-community/media/blob/master/example/src/components/SaveMedia.tsx)
    */
   getAlbumsPath(): Promise<AlbumsPathResponse>;
@@ -105,7 +105,7 @@ export interface MediaFetchOptions {
   /**
    * Which types of assets to return thumbnails for.
    */
-  types?: "photos" | "videos" | "all";
+  types?: 'photos' | 'videos' | 'all';
   /**
    * Which album identifier to query in (get identifier with getAlbums())
    */
@@ -123,7 +123,7 @@ export interface MediaSort {
 
 /**
  * Attributes to sort media by.
- * 
+ *
  * [iOS Source](https://developer.apple.com/documentation/photokit/phfetchoptions)
  */
 export type MediaField =

--- a/src/web.ts
+++ b/src/web.ts
@@ -37,7 +37,7 @@ export class MediaWeb extends WebPlugin implements MediaPlugin {
     throw this.unimplemented('Not implemented on web.');
   }
   getAlbumsPath(): Promise<AlbumsPathResponse> {
-      console.log('getAlbumsPath');
-      throw this.unimplemented('Not implemented on web.');
+    console.log('getAlbumsPath');
+    throw this.unimplemented('Not implemented on web.');
   }
 }


### PR DESCRIPTION
fmt script was broken because it was trying to lint the example folder too, removed it and ran `npm run fmt` command