### PR TITLE
add duration to response data from getMedias

### DIFF
--- a/ios/Plugin/MediaPlugin.swift
+++ b/ios/Plugin/MediaPlugin.swift
@@ -438,6 +438,7 @@ public class MediaPlugin: CAPPlugin {
                 if asset.creationDate != nil {
                     a["creationDate"] = JSDate.toString(asset.creationDate!)
                 }
+                a["duration"] = asset.duration
                 a["fullWidth"] = asset.pixelWidth
                 a["fullHeight"] = asset.pixelHeight
                 a["thumbnailWidth"] = image.size.width

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor-community/media",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Enable some media features for Capacitor such as create albums, save videos, gifs and more.",
   "author": "Stewan Silva",
   "license": "MIT",

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -13,7 +13,7 @@ export interface MediaPlugin {
    *
    * [Code Examples](https://github.com/capacitor-community/media/blob/master/example/src/components/GetMedias.tsx)
    */
-  getMediaByIdentifier(options?: { identifier: string }): Promise<MediaPath>;
+  getMediaByIdentifier(options?: {identifier: string}): Promise<MediaPath>;
   /**
    * Get list of albums.
    *
@@ -158,6 +158,10 @@ export interface MediaAsset {
    * ISO date string for creation date of asset
    */
   creationDate: string;
+  /**
+   * duration of asset in seconds
+   */
+  duration: number;
   /**
    * Full width of original asset
    */


### PR DESCRIPTION
I wanted to display the duration with the thumbnail when showing list of videos as well as limit the size of video being uploaded by our app so this small update allows us to know the duration of a video.